### PR TITLE
fix: allow 0 to be passed as a number in setDollarsEffect

### DIFF
--- a/src/components/codeGeneration/Jokers/effects/SetDollarsEffect.ts
+++ b/src/components/codeGeneration/Jokers/effects/SetDollarsEffect.ts
@@ -42,7 +42,7 @@ export const generateSetDollarsReturn = (
 
     configVariables.push({
       name: variableName,
-      value: Number(effectValue) || 5,
+      value: Number(effectValue ?? 5),
     });
   }
 


### PR DESCRIPTION
`Number(effectValue)` was previously evaluated as false when `effectValue` was 0