### PR TITLE
feat: add shop_entered trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ The plan here is to implement enough triggers, conditions, and effects, so as th
 - [x] **Card Sold** - When a card is sold
 - [x] **When this Card is Sold** - When this specific card is sold
 - [x] **Card Destroyed** - When a card is destroyed
+- [x] **When shop is Entered** - When the shop is entered
+
 
 #### Not Implemented Yet
 
 - [ ] **Ante Start** - At the start of an ante
 - [ ] **Joker Added/Removed** - When a Joker is added/removed from your list (Joker Stencil)
 - [ ] **When a Card is Modified** - When any card is modified (enhanced, etc) (difficult)
-- [ ] **When shop is Entered** - WHne the shop is entered
 - [ ] **When a Playing Card is Added** - When a playing card is added to your deck (Hologram)
 - [ ] **When this Joker is Bought** - When specifically this joker is bought (different from add to deck)
 

--- a/src/components/codeGeneration/Jokers/triggerUtils.ts
+++ b/src/components/codeGeneration/Jokers/triggerUtils.ts
@@ -92,6 +92,12 @@ export const generateTriggerContext = (
         comment: "-- When first hand is drawn",
       };
 
+    case "shop_entered":
+      return {
+        check: "context.starting_shop and not context.blueprint",
+        comment: "-- When entering shop",
+      };
+
     case "shop_exited":
       return {
         check: "context.ending_shop and not context.blueprint",

--- a/src/components/data/Jokers/Conditions.ts
+++ b/src/components/data/Jokers/Conditions.ts
@@ -36,6 +36,7 @@ export const GENERIC_TRIGGERS: string[] = [
   "consumable_used",
   "hand_drawn",
   "first_hand_drawn",
+  "shop_entered",
   "shop_exited",
   "card_discarded",
   "hand_discarded",

--- a/src/components/data/Jokers/Triggers.ts
+++ b/src/components/data/Jokers/Triggers.ts
@@ -188,6 +188,12 @@ export const TRIGGERS: TriggerDefinition[] = [
     category: "Gameplay",
   },
   {
+    id: "shop_entered",
+    label: "When Shop is Entered",
+    description: "Triggers when the player enters the shop.",
+    category: "Round Events",
+  },
+  {
     id: "shop_exited",
     label: "When Shop is Exited",
     description: "Triggers when the player exits the shop.",


### PR DESCRIPTION
spent half an hour trying to use tag contexts, turns out context.starting_shop exists

