### PR TITLE
feat: add generic triggers to level up hand effect

### DIFF
--- a/src/components/codeGeneration/Jokers/effects/LevelUpHandEffect.ts
+++ b/src/components/codeGeneration/Jokers/effects/LevelUpHandEffect.ts
@@ -77,9 +77,10 @@ export const generateLevelUpHandReturn = (
           configVariables.length > 0 ? configVariables : undefined,
       };
     } else {
+      const handToLevelUp = triggerType === "hand_played" ? "context.scoring_name" : '"High Card"'
       return {
         statement: `level_up = ${valueCode},
-                level_up_hand = context.scoring_name`,
+                level_up_hand = ${handToLevelUp}`,
         message: customMessage
           ? `"${customMessage}"`
           : `localize('k_level_up_ex')`,

--- a/src/components/data/Jokers/Effects.ts
+++ b/src/components/data/Jokers/Effects.ts
@@ -222,7 +222,7 @@ export const EFFECT_TYPES: EffectTypeDefinition[] = [
     id: "level_up_hand",
     label: "Level Up Hand",
     description: "Increase the level of a poker hand",
-    applicableTriggers: ["hand_played", "hand_discarded"],
+    applicableTriggers: [...GENERIC_TRIGGERS],
     params: [
       {
         id: "hand_selection",


### PR DESCRIPTION
couldn't find a way to hide 'current' option when selecting a different trigger than `hand_played` or `hand_discarded`

if a different trigger is selected with the 'current' option, hand upgraded will default to High Card 