### PR TITLE
fix: loc_vars not generating properly when Game var is used

### DIFF
--- a/src/components/codeGeneration/Jokers/index.ts
+++ b/src/components/codeGeneration/Jokers/index.ts
@@ -1600,7 +1600,7 @@ const generateLocVarsFunction = (
 
       locVarsReturn = `local new_numerator, new_denominator = SMODS.get_probability_vars(card, ${
         numerators[0]
-      }, ${oddsVar}, '${probabilityIdentifier}')
+      }, ${oddsVar}, '${probabilityIdentifier}') --Please-work
         return {vars = {${nonProbabilityVars.join(
           ", "
         )}, new_numerator, new_denominator}}`;
@@ -1620,7 +1620,7 @@ const generateLocVarsFunction = (
 
   return `loc_vars = function(self, info_queue, card)
         ${
-          locVarsReturn.includes("local")
+          locVarsReturn.includes("--Please-work")
             ? locVarsReturn
             : `return ${locVarsReturn}`
         }


### PR DESCRIPTION
game vars usually have a function with local keyword which broke the check for new probability change