### PR TITLE
fix: loc_vars generated one additional coma 

### DIFF
--- a/src/components/codeGeneration/Jokers/index.ts
+++ b/src/components/codeGeneration/Jokers/index.ts
@@ -1603,7 +1603,7 @@ const generateLocVarsFunction = (
       }, ${oddsVar}, '${probabilityIdentifier}') --Please-work
         return {vars = {${nonProbabilityVars.join(
           ", "
-        )}, new_numerator, new_denominator}}`;
+        )}${nonProbabilityVars.length > 0? `, ` : ``}new_numerator, new_denominator}}`;
     } else {
       locVarsReturn = `{vars = {${finalVars.join(", ")}}}`;
     }


### PR DESCRIPTION
when probability vars present and nonprobability vars missing

goodmorning sent untested code it seems like 👀 