### PR TITLE
feat: add most and least options to levelUpEffect

### DIFF
--- a/src/components/codeGeneration/Jokers/effects/LevelUpHandEffect.ts
+++ b/src/components/codeGeneration/Jokers/effects/LevelUpHandEffect.ts
@@ -61,6 +61,38 @@ export const generateLevelUpHandReturn = (
                     end
                 end
                 local target_hand = #available_hands > 0 and pseudorandom_element(available_hands, pseudoseed('level_up_hand')) or "High Card"`;
+  } else if (handSelection === "most") {
+    handDeterminationCode = `local temp_played = 0
+                            local temp_order = math.huge
+                            local target_hand
+                            for hand, value in pairs(G.GAME.hands) do
+                              if value.played > temp_played and value.visible then
+                                temp_played = value.played
+                                target_hand = hand
+                              else if value.played == temp_played and value.visible then
+                                if value.order < temp_order then
+                                  temp_order = value.order
+                                  target_hand = hand
+                                end
+                              end 
+                              end
+                            end`;
+  } else if (handSelection === "least") {
+    handDeterminationCode = `local temp_played = math.huge
+                            local temp_order = math.huge
+                            local target_hand
+                            for hand, value in pairs(G.GAME.hands) do
+                              if value.played < temp_played and value.visible then
+                                temp_played = value.played
+                                target_hand = hand
+                              else if value.played == temp_played and value.visible then
+                                if value.order < temp_order then
+                                  temp_order = value.order
+                                  target_hand = hand
+                                end
+                              end 
+                              end
+                            end`;
   } else {
     if (triggerType === "hand_discarded") {
       return {

--- a/src/components/codeGeneration/Jokers/effects/LevelUpHandEffect.ts
+++ b/src/components/codeGeneration/Jokers/effects/LevelUpHandEffect.ts
@@ -68,6 +68,7 @@ export const generateLevelUpHandReturn = (
                             for hand, value in pairs(G.GAME.hands) do
                               if value.played > temp_played and value.visible then
                                 temp_played = value.played
+                                temp_order = value.order
                                 target_hand = hand
                               else if value.played == temp_played and value.visible then
                                 if value.order < temp_order then
@@ -84,6 +85,7 @@ export const generateLevelUpHandReturn = (
                             for hand, value in pairs(G.GAME.hands) do
                               if value.played < temp_played and value.visible then
                                 temp_played = value.played
+                                temp_order = value.order
                                 target_hand = hand
                               else if value.played == temp_played and value.visible then
                                 if value.order < temp_order then

--- a/src/components/data/Jokers/Effects.ts
+++ b/src/components/data/Jokers/Effects.ts
@@ -231,6 +231,8 @@ export const EFFECT_TYPES: EffectTypeDefinition[] = [
         options: [
           { value: "current", label: "Current Hand (Played/Discarded)" },
           { value: "specific", label: "Specific Hand" },
+          { value: "most", label: "Most Played" },
+          { value: "least", label: "Least Played" },
           { value: "random", label: "Random Hand" },
         ],
         default: "current",


### PR DESCRIPTION
if tied, the priority goes to the hand with lower order (stronger hand)