### PR TITLE
feat: add blueprint compatibility logic to rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ The plan here is to implement enough triggers, conditions, and effects, so as th
 - [x] **Mod Packaging** - Complete mod folder structure with JSON metadata
 - [x] **Mod Metadata Editing** - Edit parameters like description, version, etc.
 - [x] **Sticker Compatibility** - Perishable, Rental, etc. 
+- [x] **Blueprint Compatibility Logic** - Actual blueprint behavior code
 
 #### Not Implemented Yet
 
-- [ ] **Blueprint Compatibility Logic** - Actual blueprint behavior code
 - [ ] **Unlock Condition Generation** - Custom unlock requirements
 - [ ] **Localization Support** - Multiple language support
 

--- a/src/components/codeGeneration/Jokers/triggerUtils.ts
+++ b/src/components/codeGeneration/Jokers/triggerUtils.ts
@@ -13,17 +13,19 @@ export const generateTriggerContext = (
     rule.effects.some((effect) => effect.type === "retrigger_cards")
   );
 
+  const isBlueprintCompatible = rules.some((rule) => rule.blueprintCompatible);
+
   switch (triggerType) {
     case "card_scored":
       if (hasRetriggerEffects) {
         return {
-          check: "context.repetition and context.cardarea == G.play",
+          check: `context.repetition and context.cardarea == G.play ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
           comment: "-- Card repetition context for retriggering",
         };
       } else {
         return {
           check:
-            "context.individual and context.cardarea == G.play and not context.blueprint",
+            `context.individual and context.cardarea == G.play ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
           comment: "-- Individual card scoring",
         };
       }
@@ -32,137 +34,143 @@ export const generateTriggerContext = (
       if (hasRetriggerEffects) {
         return {
           check:
-            "context.repetition and context.cardarea == G.hand and (next(context.card_effects[1]) or #context.card_effects > 1)",
+            `context.repetition and context.cardarea == G.hand and (next(context.card_effects[1]) or #context.card_effects > 1) ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
           comment: "-- Card repetition context for held cards",
         };
       } else {
         return {
           check:
-            "context.individual and context.cardarea == G.hand and not context.end_of_round and not context.blueprint",
+            `context.individual and context.cardarea == G.hand and not context.end_of_round ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
           comment: "-- Individual card held in hand",
         };
       }
 
     case "blind_selected":
       return {
-        check: "context.setting_blind and not context.blueprint",
+        check: `context.setting_blind ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When blind is selected",
       };
 
     case "blind_skipped":
       return {
-        check: "context.skip_blind and not context.blueprint",
+        check: `context.skip_blind ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When blind is skipped",
       };
 
     case "boss_defeated":
       return {
         check:
-          "context.end_of_round and context.main_eval and G.GAME.blind.boss and not context.blueprint",
+          `context.end_of_round and context.main_eval and G.GAME.blind.boss ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- After boss blind is defeated",
       };
 
     case "booster_opened":
       return {
-        check: "context.open_booster and not context.blueprint",
+        check: `context.open_booster ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When booster pack is opened",
       };
 
     case "booster_skipped":
       return {
-        check: "context.skipping_booster and not context.blueprint",
+        check: `context.skipping_booster ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When booster pack is skipped",
       };
 
     case "consumable_used":
       return {
-        check: "context.using_consumeable and not context.blueprint",
+        check: `context.using_consumeable ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When consumable is used",
       };
 
     case "hand_drawn":
       return {
-        check: "context.hand_drawn and not context.blueprint",
+        check: `context.hand_drawn ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When hand is drawn",
       };
 
     case "first_hand_drawn":
       return {
-        check: "context.first_hand_drawn and not context.blueprint",
+        check: `context.first_hand_drawn ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When first hand is drawn",
       };
 
     case "shop_entered":
       return {
-        check: "context.starting_shop and not context.blueprint",
+        check: `context.starting_shop ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When entering shop",
       };
 
     case "shop_exited":
       return {
-        check: "context.ending_shop and not context.blueprint",
+        check: `context.ending_shop ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When exiting shop",
       };
 
     case "shop_reroll":
       return {
-        check: "context.reroll_shop and not context.blueprint",
+        check: `context.reroll_shop ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When shop is rerolled",
       };
 
     case "round_end":
       return {
         check:
-          "context.end_of_round and context.game_over == false and context.main_eval and not context.blueprint",
+          `context.end_of_round and context.game_over == false and context.main_eval ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- At the end of the round",
       };
 
     case "card_discarded":
       return {
-        check: "context.discard and not context.blueprint",
+        check: `context.discard ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When card is discarded",
       };
 
     case "hand_discarded":
       return {
-        check: "context.pre_discard and not context.blueprint",
+        check: `context.pre_discard ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When hand is discarded",
+      };
+
+    case "before_hand_played":
+      return {
+        check: `context.before and context.cardarea == G.jokers ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
+        comment: "-- Before hand starts scoring",
       };
 
     case "after_hand_played":
       return {
-        check: "context.after and context.cardarea == G.jokers",
+        check: `context.after and context.cardarea == G.jokers ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- After hand has finished scoring",
       };
 
     case "card_sold":
       return {
-        check: "context.selling_card and not context.blueprint",
+        check: `context.selling_card ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When any card is sold",
       };
 
     case "card_bought":
       return {
-        check: "context.buying_card and not context.blueprint",
+        check: `context.buying_card ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When any card is bought",
       };
 
     case "selling_self":
       return {
-        check: "context.selling_self and not context.blueprint",
+        check: `context.selling_self ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When this specific joker is sold",
       };
 
     case "buying_self":
       return {
-        check: "context.buying_card and context.card.config.center.key == self.key and context.cardarea == G.jokers and not context.blueprint",
+        check: `context.buying_card and context.card.config.center.key == self.key and context.cardarea == G.jokers ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When this specific joker is bought",
       };
 
     case "game_over":
       return {
         check:
-          "context.end_of_round and context.game_over and context.main_eval and not context.blueprint",
+          `context.end_of_round and context.game_over and context.main_eval ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When the game would end (game over)",
       };
 
@@ -170,33 +178,33 @@ export const generateTriggerContext = (
       if (hasRetriggerEffects) {
         return {
           check:
-            "context.repetition and context.cardarea == G.hand and context.end_of_round and (next(context.card_effects[1]) or #context.card_effects > 1)",
+            `context.repetition and context.cardarea == G.hand and context.end_of_round and (next(context.card_effects[1]) or #context.card_effects > 1) ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
           comment: "-- Card repetition context for held cards at end of round",
         };
       } else {
         return {
           check:
-            "context.cardarea == G.hand and context.end_of_round and not context.blueprint",
+            `context.cardarea == G.hand and context.end_of_round ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
           comment: "-- When a card hand is held at the end of the round",
         };
       }
 
     case "card_destroyed":
       return {
-        check: "context.remove_playing_cards and not context.blueprint",
+        check: `context.remove_playing_cards ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When cards are destroyed",
       };
 
     case "playing_card_added":
       return {
-        check: "context.playing_card_added and not context.blueprint",
+        check: `context.playing_card_added ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- When playing cards are added to deck",
       };
 
     case "hand_played":
     default:
       return {
-        check: "context.cardarea == G.jokers and context.joker_main",
+        check: `context.cardarea == G.jokers and context.joker_main ${isBlueprintCompatible ? '' : ' and not context.blueprint'}`,
         comment: "-- Main scoring time for jokers",
       };
   }

--- a/src/components/data/Jokers/Conditions.ts
+++ b/src/components/data/Jokers/Conditions.ts
@@ -51,6 +51,7 @@ export const GENERIC_TRIGGERS: string[] = [
   "card_held_in_hand",
   "card_held_in_hand_end_of_round",
   "after_hand_played",
+  "before_hand_played",
   "card_sold",
   "card_bought",
   "selling_self",
@@ -119,7 +120,7 @@ export const CONDITION_TYPES: ConditionTypeDefinition[] = [
     id: "hand_type",
     label: "Hand Type",
     description: "Check the type of poker hand",
-    applicableTriggers: ["hand_played", "card_scored", "after_hand_played"],
+    applicableTriggers: ["hand_played", "card_scored", "after_hand_played", "before_hand_played"],
     params: [
       {
         id: "card_scope",
@@ -155,7 +156,7 @@ export const CONDITION_TYPES: ConditionTypeDefinition[] = [
     id: "card_count",
     label: "Card Count",
     description: "Check the number of cards in the played hand",
-    applicableTriggers: ["hand_played", "card_scored", "after_hand_played"],
+    applicableTriggers: ["hand_played", "card_scored", "after_hand_played", "before_hand_played"],
     params: [
       {
         id: "card_scope",
@@ -183,7 +184,7 @@ export const CONDITION_TYPES: ConditionTypeDefinition[] = [
     id: "suit_count",
     label: "Suit Count",
     description: "Check how many cards of a specific suit are in the hand",
-    applicableTriggers: ["hand_played", "card_scored", "after_hand_played"],
+    applicableTriggers: ["hand_played", "card_scored", "after_hand_played", "before_hand_played"],
     params: [
       {
         id: "card_scope",
@@ -251,7 +252,7 @@ export const CONDITION_TYPES: ConditionTypeDefinition[] = [
     id: "rank_count",
     label: "Rank Count",
     description: "Check how many cards of a specific rank are in the hand",
-    applicableTriggers: ["hand_played", "card_scored", "after_hand_played"],
+    applicableTriggers: ["hand_played", "card_scored", "after_hand_played", "before_hand_played"],
     params: [
       {
         id: "card_scope",
@@ -675,9 +676,8 @@ export const CONDITION_TYPES: ConditionTypeDefinition[] = [
   {
     id: "enhancement_count",
     label: "Enhancement Count",
-    description:
-      "Check how many cards with a specific enhancement are in the hand",
-    applicableTriggers: ["hand_played", "card_scored", "after_hand_played"],
+    applicableTriggers: ["hand_played", "card_scored", "after_hand_played", "before_hand_played"],
+    description: "Check how many cards with a specific enhancement are in the hand",
     params: [
       {
         id: "card_scope",
@@ -711,7 +711,7 @@ export const CONDITION_TYPES: ConditionTypeDefinition[] = [
     id: "edition_count",
     label: "Edition Count",
     description: "Check how many cards with a specific edition are in the hand",
-    applicableTriggers: ["hand_played", "card_scored", "after_hand_played"],
+    applicableTriggers: ["hand_played", "card_scored", "after_hand_played", "before_hand_played"],
     params: [
       {
         id: "card_scope",
@@ -745,7 +745,7 @@ export const CONDITION_TYPES: ConditionTypeDefinition[] = [
     id: "seal_count",
     label: "Seal Count",
     description: "Check how many cards with a specific seal are in the hand",
-    applicableTriggers: ["hand_played", "card_scored", "after_hand_played"],
+    applicableTriggers: ["hand_played", "card_scored", "after_hand_played", "before_hand_played"],
     params: [
       {
         id: "card_scope",
@@ -780,15 +780,15 @@ export const CONDITION_TYPES: ConditionTypeDefinition[] = [
     label: "Poker Hand Been Played",
     description:
       "Check if the current poker hand has already been played this round",
-    applicableTriggers: ["hand_played", "card_scored", "after_hand_played"],
+    applicableTriggers: ["hand_played", "card_scored", "after_hand_played", "before_hand_played"],
     params: [],
     category: "Hand",
   },
   {
     id: "cumulative_chips",
     label: "Cumulative Chips",
+    applicableTriggers: ["hand_played", "card_scored", "after_hand_played", "before_hand_played"],
     description: "Check the sum of chips in hand",
-    applicableTriggers: ["hand_played", "card_scored", "after_hand_played"],
     params: [
       {
         id: "hand",
@@ -1376,6 +1376,7 @@ export const CONDITION_TYPES: ConditionTypeDefinition[] = [
       "Check what percentage of the blind requirement the current base hand score represents (e.g., 110% means you've exceeded the blind by 10%, values over 100% check if you've exceeded the blind)",
     applicableTriggers: [
       "after_hand_played",
+      "before_hand_played",
       "hand_played",
       "card_scored",
       "round_end",
@@ -1453,6 +1454,7 @@ export const CONDITION_TYPES: ConditionTypeDefinition[] = [
       "card_scored",
       "card_discarded",
       "after_hand_played",
+      "before_hand_played"
     ],
     params: [],
     category: "Game State",

--- a/src/components/data/Jokers/Triggers.ts
+++ b/src/components/data/Jokers/Triggers.ts
@@ -105,6 +105,13 @@ export const TRIGGERS: TriggerDefinition[] = [
     category: "Gameplay",
   },
   {
+    id: "before_hand_played",
+    label: "Before Hand Starts Scoring",
+    description:
+      "Triggers before a hand starts the scoring sequence or any jokers have been calculated. Perfect for scaling jokers or effects that should happen once per hand before everything else.",
+    category: "Gameplay",
+  },
+  {
     id: "round_end",
     label: "When the Round Ends",
     description:

--- a/src/components/pages/jokers/JokerCard.tsx
+++ b/src/components/pages/jokers/JokerCard.tsx
@@ -3,7 +3,6 @@ import {
   PencilIcon,
   PuzzlePieceIcon,
   DocumentDuplicateIcon,
-  DocumentIcon,
   StarIcon,
   TrashIcon,
   ArrowDownTrayIcon,
@@ -16,6 +15,7 @@ import {
   NoSymbolIcon,
   ClockIcon,
   CurrencyDollarIcon,
+  WrenchIcon,
 } from "@heroicons/react/24/solid";
 
 import Tooltip from "../../generic/Tooltip";
@@ -221,7 +221,7 @@ const JokerCard: React.FC<JokerCardProps> = ({
 
   const propertyIcons = [
     {
-      icon: <DocumentIcon className="w-full h-full" />,
+      icon: <WrenchIcon className="w-full h-full" />,
       tooltip: blueprintCompat
         ? "Blueprint Compatible"
         : "Cannot be copied by Blueprint",

--- a/src/components/ruleBuilder/RuleBuilder.tsx
+++ b/src/components/ruleBuilder/RuleBuilder.tsx
@@ -715,6 +715,7 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({
     const newRule: Rule = {
       id: crypto.randomUUID(),
       trigger: triggerId,
+      blueprintCompatible: true,
       conditionGroups: [],
       effects: [],
       randomGroups: [],
@@ -891,6 +892,20 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({
       ruleId: ruleId,
       randomGroupId: newGroup.id,
     });
+  };
+
+ const toggleBlueprintCompatibility = (ruleId: string) => {
+    setRules((prev) =>
+      prev.map((rule) => {
+        if (rule.id === ruleId) {
+          return {
+            ...rule,
+            blueprintCompatible: !rule.blueprintCompatible
+          };
+        }
+        return rule;
+      })
+    );
   };
 
   const deleteRandomGroup = (ruleId: string, randomGroupId: string) => {
@@ -1546,6 +1561,7 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({
                             onDeleteEffect={deleteEffect}
                             onAddConditionGroup={addConditionGroup}
                             onAddRandomGroup={addRandomGroup}
+                            onToggleBlueprintCompatibility={toggleBlueprintCompatibility}
                             onDeleteRandomGroup={deleteRandomGroup}
                             onToggleGroupOperator={toggleGroupOperator}
                             onUpdatePosition={updateRulePosition}

--- a/src/components/ruleBuilder/RuleCard.tsx
+++ b/src/components/ruleBuilder/RuleCard.tsx
@@ -22,7 +22,7 @@ import { getConsumableConditionTypeById } from "../data/Consumables/Conditions";
 import { getConsumableEffectTypeById } from "../data/Consumables/Effects";
 
 import BlockComponent from "./BlockComponent";
-import { ChevronDownIcon, Bars3Icon } from "@heroicons/react/24/outline";
+import { ChevronDownIcon, Bars3Icon} from "@heroicons/react/24/outline";
 import {
   TrashIcon,
   PlusIcon,
@@ -33,6 +33,7 @@ import {
 } from "@heroicons/react/16/solid";
 import { JokerData } from "../data/BalatroUtils";
 import { ConsumableData } from "../data/BalatroUtils";
+import { WrenchIcon } from "@heroicons/react/24/solid";
 
 interface RuleCardProps {
   rule: Rule;
@@ -58,6 +59,7 @@ interface RuleCardProps {
   onDeleteEffect: (ruleId: string, effectId: string) => void;
   onAddConditionGroup: (ruleId: string) => void;
   onAddRandomGroup: (ruleId: string) => void;
+  onToggleBlueprintCompatibility: (ruleId: string) => void;
   onDeleteRandomGroup: (ruleId: string, randomGroupId: string) => void;
   onToggleGroupOperator?: (ruleId: string, groupId: string) => void;
   onUpdatePosition: (
@@ -254,6 +256,7 @@ const RuleCard: React.FC<RuleCardProps> = ({
   onDeleteConditionGroup,
   onDeleteEffect,
   onAddConditionGroup,
+  onToggleBlueprintCompatibility,
   onAddRandomGroup,
   onDeleteRandomGroup,
   onToggleGroupOperator,
@@ -814,11 +817,31 @@ const RuleCard: React.FC<RuleCardProps> = ({
                   <div onClick={(e) => e.stopPropagation()}>
                     <button
                       onClick={() => onAddRandomGroup(rule.id)}
-                      className="w-6 h-6 bg-black-darker rounded-lg flex items-center justify-center border-2 border-effect hover:bg-effect/20 transition-colors"
+                      className="w-6 h-6 bg-black-darker rounded-lg flex items-center justify-center border-2 border-effect hover:bg-effect/20 transition-colors cursor-pointer"
                       title="Add Random Group"
                     >
                       <PlusIcon className="h-3 w-3 text-effect" />
                     </button>
+                  </div>
+                  <div onClick={(e) => e.stopPropagation()}>
+                    {rule.blueprintCompatible 
+                    ?
+                    <button
+                      onClick={() => onToggleBlueprintCompatibility(rule.id)}
+                      className="w-6 h-6 bg-black-darker rounded-lg flex items-center justify-center border-2 border-balatro-blue hover:bg-balatro-blue/20 transition-colors cursor-pointer"
+                      title="Blueprint Compatible"
+                    >
+                      <WrenchIcon className="h-3 w-3 text-balatro-blue" />
+                    </button>
+                    :
+                    <button
+                      onClick={() => onToggleBlueprintCompatibility(rule.id)}
+                      className="w-6 h-6 bg-black-darker rounded-lg flex items-center justify-center border-2 border-balatro-red hover:bg-balatro-red/20 transition-colors cursor-pointer"
+                      title="Not Compatible with Blueprint"
+                    >
+                      <WrenchIcon className="h-3 w-3 text-balatro-red" />
+                    </button>
+                    }
                   </div>
                 </div>
               </motion.div>

--- a/src/components/ruleBuilder/types.ts
+++ b/src/components/ruleBuilder/types.ts
@@ -3,6 +3,7 @@ export interface Rule {
   position: { x: number; y: number };
   id: string;
   trigger: string;
+  blueprintCompatible: boolean;
   conditionGroups: ConditionGroup[];
   effects: Effect[];
   randomGroups: RandomGroup[];


### PR DESCRIPTION
tested with only some triggers, but in theory it should all work

there are some vanilla jokers that need to be redone (like Spare Trousers) to implement the 'Before Hand Scores' trigger and correctly assign compatibility
