### PR TITLE
feat: add saving to user configs (autoformat, gridsnapping, filters)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,7 @@ import DonationNotification from "./components/generic/DonationNotification";
 import RestoreProgressModal from "./components/generic/RestoreProgressModal";
 import { DEFAULT_MOD_METADATA } from "./components/pages/ModMetadataPage";
 import SkeletonPage from "./components/pages/SkeletonPage";
+import { UserConfigProvider } from "./components/Contexts";
 interface AlertState {
   isVisible: boolean;
   type: "success" | "warning" | "error";
@@ -1480,9 +1481,11 @@ function AppContent() {
 
 function App() {
   return (
-    <Router>
-      <AppContent />
-    </Router>
+    <UserConfigProvider>
+      <Router>
+        <AppContent />
+      </Router>
+    </UserConfigProvider>
   );
 }
 

--- a/src/components/Contexts.tsx
+++ b/src/components/Contexts.tsx
@@ -1,0 +1,52 @@
+import { createContext, ReactNode, useCallback, useEffect, useState } from "react";
+import { UserConfig } from "./data/BalatroUtils";
+
+const USER_CONFIG_KEY = "joker-forge-user-config";
+
+interface UserConfigContextType {
+  userConfig: UserConfig;
+  setUserConfig: React.Dispatch<React.SetStateAction<UserConfig>>;
+}
+
+export const UserConfigContext = createContext<UserConfigContextType>({
+  userConfig: {filters: {}, defaultAutoFormat: true, defaultGridSnap: false },
+  setUserConfig: () => {}
+});
+
+type ContextProviderProps = {
+  children: ReactNode;
+};
+
+export const UserConfigProvider = ({ children }: ContextProviderProps) => {
+  const loadUserConfig = useCallback((): UserConfig => {
+    try {
+      const stored = localStorage.getItem(USER_CONFIG_KEY);
+      return stored
+        ? JSON.parse(stored)
+        : {
+            filters: {},
+            defaultAutoFormat: true,
+            defaultGridSnap: false,
+          };
+    } catch (err) {
+      console.error("Failed to parse userConfig from localStorage", err);
+      return {
+        filters: {},
+        defaultAutoFormat: true,
+        defaultGridSnap: false,
+      };
+    }
+  }, []);
+
+  const [userConfig, setUserConfig] = useState<UserConfig>(() => loadUserConfig());
+
+  useEffect(() => {
+    localStorage.setItem(USER_CONFIG_KEY, JSON.stringify(userConfig));
+  }, [userConfig]);
+
+  return (
+    <UserConfigContext.Provider value={{ userConfig, setUserConfig }}>
+      {children}
+    </UserConfigContext.Provider>
+  );
+};

--- a/src/components/data/BalatroUtils.ts
+++ b/src/components/data/BalatroUtils.ts
@@ -32,6 +32,18 @@ export interface ModMetadata {
   hasUserUploadedIcon?: boolean;
 }
 
+export interface UserConfig {
+  filters: {
+    jokersFilter?: string,
+    consumablesFilter?: string,
+    boostersFilter?: string,
+    enhancementsFilter?: string,
+    sealsFilter?: string,
+  },
+  defaultAutoFormat: boolean,
+  defaultGridSnap: boolean,
+}
+
 // =============================================================================
 // DATA REGISTRY INTERFACES
 // =============================================================================

--- a/src/components/pages/BoostersPage.tsx
+++ b/src/components/pages/BoostersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, useRef } from "react";
+import React, { useState, useMemo, useEffect, useRef, useContext } from "react";
 import ReactDOM from "react-dom";
 import {
   PlusIcon,
@@ -26,6 +26,7 @@ import {
 } from "../data/BalatroUtils";
 import BoosterCard from "./boosters/BoosterCard";
 import EditBoosterInfo from "./boosters/EditBoosterInfo";
+import { UserConfigContext } from "../Contexts";
 
 interface BoostersPageProps {
   modName: string;
@@ -580,6 +581,7 @@ const BoostersPage: React.FC<BoostersPageProps> = ({
   consumableSets,
   showConfirmation,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext) 
   const [editingBooster, setEditingBooster] = useState<BoosterData | null>(
     null
   );
@@ -601,7 +603,7 @@ const BoostersPage: React.FC<BoostersPageProps> = ({
     boosterKey: "",
   });
   const [searchTerm, setSearchTerm] = useState("");
-  const [sortBy, setSortBy] = useState("name-asc");
+  const [sortBy, setSortBy] = useState(userConfig.filters.boostersFilter ?? "name-asc");
   const [showSortMenu, setShowSortMenu] = useState(false);
   const [sortMenuPosition, setSortMenuPosition] = useState({
     top: 0,
@@ -1004,6 +1006,13 @@ const BoostersPage: React.FC<BoostersPageProps> = ({
                     key={option.value}
                     onClick={(e) => {
                       e.stopPropagation();
+                      setUserConfig(prevConfig => ({
+                        ...prevConfig,
+                        filters: {
+                          ...prevConfig.filters,
+                          boostersFilter: option.value
+                        }
+                      }))
                       setSortBy(option.value);
                       setShowSortMenu(false);
                     }}

--- a/src/components/pages/ConsumablesPage.tsx
+++ b/src/components/pages/ConsumablesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, useContext } from "react";
 import ReactDOM from "react-dom";
 import {
   PlusIcon,
@@ -30,6 +30,7 @@ import {
   ConsumableData,
 } from "../data/BalatroUtils";
 import { exportSingleConsumable } from "../codeGeneration/Consumables";
+import { UserConfigContext } from "../Contexts";
 
 interface ConsumablesPageProps {
   modName: string;
@@ -720,6 +721,7 @@ const ConsumablesPage: React.FC<ConsumablesPageProps> = ({
   setConsumableSets,
   showConfirmation,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext)
   const [activeTab, setActiveTab] = useState<"consumables" | "sets">(
     "consumables"
   );
@@ -740,7 +742,7 @@ const ConsumablesPage: React.FC<ConsumablesPageProps> = ({
   const [searchTerm, setSearchTerm] = useState("");
   const [setFilter, setSetFilter] = useState<string | null>(null);
   const [showFilters, setShowFilters] = useState(false);
-  const [sortBy, setSortBy] = useState("name-asc");
+  const [sortBy, setSortBy] = useState(userConfig.filters.consumablesFilter ?? "name-asc");
   const [showSortMenu, setShowSortMenu] = useState(false);
   const [sortMenuPosition, setSortMenuPosition] = useState({
     top: 0,
@@ -1495,6 +1497,13 @@ const ConsumablesPage: React.FC<ConsumablesPageProps> = ({
                     key={option.value}
                     onClick={(e) => {
                       e.stopPropagation();
+                      setUserConfig(prevConfig => ({
+                        ...prevConfig,
+                        filters: {
+                          ...prevConfig.filters,
+                          consumablesFilter: option.value
+                        }
+                      }))
                       setSortBy(option.value);
                       setShowSortMenu(false);
                     }}

--- a/src/components/pages/EnhancementsPage.tsx
+++ b/src/components/pages/EnhancementsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, useContext } from "react";
 import ReactDOM from "react-dom";
 import {
   PlusIcon,
@@ -15,6 +15,7 @@ import Button from "../generic/Button";
 import { exportSingleEnhancement } from "../codeGeneration/Card/index";
 import type { Rule } from "../ruleBuilder/types";
 import { EnhancementData, slugify } from "../data/BalatroUtils";
+import { UserConfigContext } from "../Contexts";
 
 interface EnhancementsPageProps {
   modName: string;
@@ -168,13 +169,14 @@ const EnhancementsPage: React.FC<EnhancementsPageProps> = ({
   modPrefix,
   showConfirmation,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext) 
   const [editingEnhancement, setEditingEnhancement] =
     useState<EnhancementData | null>(null);
   const [showRuleBuilder, setShowRuleBuilder] = useState(false);
   const [currentEnhancementForRules, setCurrentEnhancementForRules] =
     useState<EnhancementData | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
-  const [sortBy, setSortBy] = useState("name-asc");
+  const [sortBy, setSortBy] = useState(userConfig.filters.enhancementsFilter ?? "name-asc");
   const [showSortMenu, setShowSortMenu] = useState(false);
   const [sortMenuPosition, setSortMenuPosition] = useState({
     top: 0,
@@ -555,6 +557,13 @@ const EnhancementsPage: React.FC<EnhancementsPageProps> = ({
                     key={option.value}
                     onClick={(e) => {
                       e.stopPropagation();
+                      setUserConfig(prevConfig => ({
+                        ...prevConfig,
+                        filters: {
+                          ...prevConfig.filters,
+                          enhancementsFilter: option.value
+                        }
+                      }))
                       setSortBy(option.value);
                       setShowSortMenu(false);
                     }}

--- a/src/components/pages/JokersPage.tsx
+++ b/src/components/pages/JokersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, useContext } from "react";
 import ReactDOM from "react-dom";
 import {
   PlusIcon,
@@ -15,6 +15,7 @@ import Button from "../generic/Button";
 import { exportSingleJoker } from "../codeGeneration/Jokers/index";
 import type { Rule } from "../ruleBuilder/types";
 import { RarityData, JokerData } from "../data/BalatroUtils";
+import { UserConfigContext } from "../Contexts";
 
 interface JokersPageProps {
   modName: string;
@@ -168,6 +169,7 @@ const JokersPage: React.FC<JokersPageProps> = ({
   modPrefix,
   showConfirmation,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext)
   const [editingJoker, setEditingJoker] = useState<JokerData | null>(null);
   const [showRuleBuilder, setShowRuleBuilder] = useState(false);
   const [currentJokerForRules, setCurrentJokerForRules] =
@@ -175,7 +177,7 @@ const JokersPage: React.FC<JokersPageProps> = ({
   const [searchTerm, setSearchTerm] = useState("");
   const [rarityFilter, setRarityFilter] = useState<number | null>(null);
   const [showFilters, setShowFilters] = useState(false);
-  const [sortBy, setSortBy] = useState("name-asc");
+  const [sortBy, setSortBy] = useState(userConfig.filters.jokersFilter ?? "name-asc");
   const [showSortMenu, setShowSortMenu] = useState(false);
   const [sortMenuPosition, setSortMenuPosition] = useState({
     top: 0,
@@ -658,6 +660,13 @@ const JokersPage: React.FC<JokersPageProps> = ({
                     key={option.value}
                     onClick={(e) => {
                       e.stopPropagation();
+                      setUserConfig(prevConfig => ({
+                        ...prevConfig,
+                        filters: {
+                          ...prevConfig.filters,
+                          jokersFilter: option.value
+                        }
+                      }))
                       setSortBy(option.value);
                       setShowSortMenu(false);
                     }}

--- a/src/components/pages/RaritiesPage.tsx
+++ b/src/components/pages/RaritiesPage.tsx
@@ -3,7 +3,6 @@ import {
   PlusIcon,
   MagnifyingGlassIcon,
   PencilIcon,
-  TrashIcon,
   DocumentDuplicateIcon,
   SwatchIcon,
   InformationCircleIcon,
@@ -15,6 +14,7 @@ import InputField from "../generic/InputField";
 import Modal from "../generic/Modal";
 import { validateJokerName } from "../generic/validationUtils";
 import { RarityData } from "../data/BalatroUtils";
+import { TrashIcon } from "@heroicons/react/24/solid";
 
 interface RaritiesPageProps {
   modName: string;

--- a/src/components/pages/SealsPage.tsx
+++ b/src/components/pages/SealsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, useContext } from "react";
 import ReactDOM from "react-dom";
 import {
   PlusIcon,
@@ -15,6 +15,7 @@ import Button from "../generic/Button";
 import { exportSingleSeal } from "../codeGeneration/Card/index";
 import type { Rule } from "../ruleBuilder/types";
 import { SealData, slugify } from "../data/BalatroUtils";
+import { UserConfigContext } from "../Contexts";
 
 interface SealsPageProps {
   modName: string;
@@ -166,12 +167,13 @@ const SealsPage: React.FC<SealsPageProps> = ({
   modPrefix,
   showConfirmation,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext) 
   const [editingSeal, setEditingSeal] = useState<SealData | null>(null);
   const [showRuleBuilder, setShowRuleBuilder] = useState(false);
   const [currentSealForRules, setCurrentSealForRules] =
     useState<SealData | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
-  const [sortBy, setSortBy] = useState("name-asc");
+  const [sortBy, setSortBy] = useState(userConfig.filters.sealsFilter ?? "name-asc");
   const [showSortMenu, setShowSortMenu] = useState(false);
   const [sortMenuPosition, setSortMenuPosition] = useState({
     top: 0,
@@ -533,6 +535,13 @@ const SealsPage: React.FC<SealsPageProps> = ({
                     key={option.value}
                     onClick={(e) => {
                       e.stopPropagation();
+                      setUserConfig(prevConfig => ({
+                        ...prevConfig,
+                        filters: {
+                          ...prevConfig.filters,
+                          sealsFilter: option.value
+                        }
+                      }))
                       setSortBy(option.value);
                       setShowSortMenu(false);
                     }}

--- a/src/components/pages/boosters/EditBoosterInfo.tsx
+++ b/src/components/pages/boosters/EditBoosterInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useContext } from "react";
 import {
   DocumentTextIcon,
   PhotoIcon,
@@ -15,6 +15,7 @@ import InputDropdown from "../../generic/InputDropdown";
 import BalatroCard from "../../generic/BalatroCard";
 import { applyAutoFormatting } from "../../generic/balatroTextFormatter";
 import { BoosterData, BoosterType } from "../../data/BalatroUtils";
+import { UserConfigContext } from "../../Contexts";
 
 interface EditBoosterInfoProps {
   isOpen: boolean;
@@ -33,6 +34,7 @@ const EditBoosterInfo: React.FC<EditBoosterInfoProps> = ({
   formData,
   onFormDataChange,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext)
   const [activeTab, setActiveTab] = useState<
     "visual" | "description" | "settings"
   >("visual");
@@ -40,7 +42,7 @@ const EditBoosterInfo: React.FC<EditBoosterInfoProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [lastDescription, setLastDescription] = useState<string>("");
-  const [autoFormatEnabled, setAutoFormatEnabled] = useState(true);
+  const [autoFormatEnabled, setAutoFormatEnabled] = useState(userConfig.defaultAutoFormat ?? true);
   const [lastFormattedText, setLastFormattedText] = useState<string>("");
   const [placeholderCredits, setPlaceholderCredits] = useState<
     Record<number, string>
@@ -669,9 +671,13 @@ const EditBoosterInfo: React.FC<EditBoosterInfoProps> = ({
                         <Button
                           size="sm"
                           variant={autoFormatEnabled ? "primary" : "secondary"}
-                          onClick={() =>
+                          onClick={() => {
+                            setUserConfig(prevConfig => ({
+                              ...prevConfig,
+                              defaultAutoFormat: !autoFormatEnabled
+                            }))
                             setAutoFormatEnabled(!autoFormatEnabled)
-                          }
+                          }}
                           icon={<SparklesIcon className="h-3 w-3" />}
                         >
                           Auto Format

--- a/src/components/pages/consumables/EditConsumableInfo.tsx
+++ b/src/components/pages/consumables/EditConsumableInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback, useContext } from "react";
 import {
   PhotoIcon,
   SparklesIcon,
@@ -20,6 +20,7 @@ import {
 } from "../../generic/validationUtils";
 import { ConsumableSetData } from "../../data/BalatroUtils";
 import { applyAutoFormatting } from "../../generic/balatroTextFormatter";
+import { UserConfigContext } from "../../Contexts";
 
 interface EditConsumableInfoProps {
   isOpen: boolean;
@@ -49,6 +50,7 @@ const EditConsumableInfo: React.FC<EditConsumableInfoProps> = ({
   availableSets,
   showConfirmation,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext)
   const [formData, setFormData] = useState<ConsumableData>(consumable);
   const [activeTab, setActiveTab] = useState<"visual" | "description">(
     "visual"
@@ -59,7 +61,7 @@ const EditConsumableInfo: React.FC<EditConsumableInfoProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
 
   const [lastDescription, setLastDescription] = useState<string>("");
-  const [autoFormatEnabled, setAutoFormatEnabled] = useState(true);
+  const [autoFormatEnabled, setAutoFormatEnabled] = useState(userConfig.defaultAutoFormat ?? true);
   const [fallbackAttempted, setFallbackAttempted] = useState(false);
   const [lastFormattedText, setLastFormattedText] = useState<string>("");
 
@@ -803,9 +805,13 @@ const EditConsumableInfo: React.FC<EditConsumableInfoProps> = ({
                   itemType="consumable"
                   textAreaId="consumable-description-edit"
                   autoFormatEnabled={autoFormatEnabled}
-                  onAutoFormatToggle={() =>
+                  onAutoFormatToggle={() => {
+                    setUserConfig(prevConfig => ({
+                      ...prevConfig,
+                      defaultAutoFormat: !autoFormatEnabled
+                    }))
                     setAutoFormatEnabled(!autoFormatEnabled)
-                  }
+                  }}
                   validationResult={validationResults.description}
                   placeholder="Describe your consumable's effects using Balatro formatting..."
                   onInsertTag={insertTagSmart}

--- a/src/components/pages/enhancements/EditEnhancementInfo.tsx
+++ b/src/components/pages/enhancements/EditEnhancementInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback, useContext } from "react";
 import {
   PhotoIcon,
   BoltIcon,
@@ -17,6 +17,7 @@ import {
   ValidationResult,
 } from "../../generic/validationUtils";
 import { applyAutoFormatting } from "../../generic/balatroTextFormatter";
+import { UserConfigContext } from "../../Contexts";
 
 interface EditEnhancementInfoProps {
   isOpen: boolean;
@@ -44,6 +45,7 @@ const EditEnhancementInfo: React.FC<EditEnhancementInfoProps> = ({
   onDelete,
   showConfirmation,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext)
   const [formData, setFormData] = useState<EnhancementData>(enhancement);
   const [activeTab, setActiveTab] = useState<"visual" | "description">(
     "visual"
@@ -53,7 +55,7 @@ const EditEnhancementInfo: React.FC<EditEnhancementInfoProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
 
   const [lastDescription, setLastDescription] = useState<string>("");
-  const [autoFormatEnabled, setAutoFormatEnabled] = useState(true);
+  const [autoFormatEnabled, setAutoFormatEnabled] = useState(userConfig.defaultAutoFormat ?? true);
   const [fallbackAttempted, setFallbackAttempted] = useState(false);
   const [lastFormattedText, setLastFormattedText] = useState<string>("");
 
@@ -725,9 +727,13 @@ const EditEnhancementInfo: React.FC<EditEnhancementInfoProps> = ({
                   itemType="enhancement"
                   textAreaId="enhancement-description-edit"
                   autoFormatEnabled={autoFormatEnabled}
-                  onAutoFormatToggle={() =>
+                  onAutoFormatToggle={() => {
+                    setUserConfig(prevConfig => ({
+                      ...prevConfig,
+                      defaultAutoFormat: !autoFormatEnabled
+                    }))
                     setAutoFormatEnabled(!autoFormatEnabled)
-                  }
+                  }}
                   validationResult={validationResults.description}
                   placeholder="Describe your enhancement's effects using Balatro formatting..."
                   onInsertTag={insertTagSmart}

--- a/src/components/pages/jokers/EditJokerInfo.tsx
+++ b/src/components/pages/jokers/EditJokerInfo.tsx
@@ -4,6 +4,7 @@ import React, {
   useEffect,
   useCallback,
   useMemo,
+  useContext,
 } from "react";
 import {
   PhotoIcon,
@@ -13,7 +14,6 @@ import {
   PuzzlePieceIcon,
   PlusIcon,
   Cog6ToothIcon,
-  TrashIcon,
 } from "@heroicons/react/24/outline";
 import InputField from "../../generic/InputField";
 import InputDropdown from "../../generic/InputDropdown";
@@ -40,11 +40,13 @@ import { applyAutoFormatting } from "../../generic/balatroTextFormatter";
 import {
   BuildingStorefrontIcon,
   LockOpenIcon,
+  TrashIcon,
 } from "@heroicons/react/24/solid";
 import {
   unlockOptions,
   unlockTriggerOptions,
 } from "../../codeGeneration/Jokers/unlockUtils";
+import { UserConfigContext } from "../../Contexts";
 
 interface EditJokerInfoProps {
   isOpen: boolean;
@@ -81,6 +83,7 @@ const EditJokerInfo: React.FC<EditJokerInfoProps> = ({
   customRarities = [],
   showConfirmation,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext)
   const [formData, setFormData] = useState<JokerData>(joker);
   const [activeTab, setActiveTab] = useState<
     "visual" | "description" | "settings"
@@ -91,7 +94,7 @@ const EditJokerInfo: React.FC<EditJokerInfoProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
 
   const [lastDescription, setLastDescription] = useState<string>("");
-  const [autoFormatEnabled, setAutoFormatEnabled] = useState(true);
+  const [autoFormatEnabled, setAutoFormatEnabled] = useState(userConfig.defaultAutoFormat ?? true);
   const [fallbackAttempted, setFallbackAttempted] = useState(false);
   const [lastFormattedText, setLastFormattedText] = useState<string>("");
 
@@ -1178,9 +1181,13 @@ const EditJokerInfo: React.FC<EditJokerInfoProps> = ({
                   itemType="joker"
                   textAreaId="joker-description-edit"
                   autoFormatEnabled={autoFormatEnabled}
-                  onAutoFormatToggle={() =>
+                  onAutoFormatToggle={() => {
+                    setUserConfig(prevConfig => ({
+                      ...prevConfig,
+                      defaultAutoFormat: !autoFormatEnabled
+                    }))
                     setAutoFormatEnabled(!autoFormatEnabled)
-                  }
+                  }}
                   validationResult={validationResults.description}
                   placeholder="Describe your joker's effects using Balatro formatting..."
                   onInsertTag={insertTagSmart}

--- a/src/components/pages/seals/EditSealInfo.tsx
+++ b/src/components/pages/seals/EditSealInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback, useContext } from "react";
 import {
   PhotoIcon,
   BoltIcon,
@@ -18,6 +18,7 @@ import {
   ValidationResult,
 } from "../../generic/validationUtils";
 import { applyAutoFormatting } from "../../generic/balatroTextFormatter";
+import { UserConfigContext } from "../../Contexts";
 
 interface EditSealInfoProps {
   isOpen: boolean;
@@ -72,6 +73,7 @@ const EditSealInfo: React.FC<EditSealInfoProps> = ({
   onDelete,
   showConfirmation,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext)
   const [formData, setFormData] = useState<SealData>(seal);
   const [activeTab, setActiveTab] = useState<
     "visual" | "description" | "colour"
@@ -81,7 +83,7 @@ const EditSealInfo: React.FC<EditSealInfoProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
 
   const [lastDescription, setLastDescription] = useState<string>("");
-  const [autoFormatEnabled, setAutoFormatEnabled] = useState(true);
+  const [autoFormatEnabled, setAutoFormatEnabled] = useState(userConfig.defaultAutoFormat ?? true);
   const [fallbackAttempted, setFallbackAttempted] = useState(false);
   const [lastFormattedText, setLastFormattedText] = useState<string>("");
 
@@ -686,9 +688,13 @@ const EditSealInfo: React.FC<EditSealInfoProps> = ({
                   itemType="seal"
                   textAreaId="seal-description-edit"
                   autoFormatEnabled={autoFormatEnabled}
-                  onAutoFormatToggle={() =>
+                  onAutoFormatToggle={() => {
+                    setUserConfig(prevConfig => ({
+                      ...prevConfig,
+                      defaultAutoFormat: !autoFormatEnabled
+                    }))
                     setAutoFormatEnabled(!autoFormatEnabled)
-                  }
+                  }}
                   validationResult={validationResults.description}
                   placeholder="Describe your seal's effects using Balatro formatting..."
                   onInsertTag={insertTagSmart}

--- a/src/components/ruleBuilder/BlockComponent.tsx
+++ b/src/components/ruleBuilder/BlockComponent.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
 import {
-  TrashIcon,
   ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline";
 import {
@@ -9,6 +8,7 @@ import {
   PuzzlePieceIcon,
   BeakerIcon,
   PercentBadgeIcon,
+  TrashIcon,
 } from "@heroicons/react/16/solid";
 
 interface BlockComponentProps {

--- a/src/components/ruleBuilder/RuleBuilder.tsx
+++ b/src/components/ruleBuilder/RuleBuilder.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback, useContext } from "react";
 import {
   TransformWrapper,
   TransformComponent,
@@ -51,6 +51,7 @@ import {
 } from "../data/BalatroUtils";
 import { getCardConditionTypeById } from "../data/Card/Conditions";
 import { getCardEffectTypeById } from "../data/Card/Effects";
+import { UserConfigContext } from "../Contexts";
 
 export type ItemData = JokerData | ConsumableData | EnhancementData | SealData;
 type ItemType = "joker" | "consumable" | "card";
@@ -90,6 +91,8 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({
   onUpdateItem,
   itemType,
 }) => {
+  const {userConfig, setUserConfig} = useContext(UserConfigContext)
+
   const [activeId, setActiveId] = useState<string | null>(null);
 
   const [inspectorIsOpen, setInspectorIsOpen] = useState(false);
@@ -113,7 +116,7 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({
   const [selectedItem, setSelectedItem] = useState<SelectedItem>(null);
   const [panState, setPanState] = useState({ x: 0, y: 0, scale: 1 });
   const [backgroundOffset, setBackgroundOffset] = useState({ x: 0, y: 0 });
-  const [gridSnapping, setGridSnapping] = useState<boolean>(false)
+  const [gridSnapping, setGridSnapping] = useState<boolean>(userConfig.defaultGridSnap ?? false)
   const [panels, setPanels] = useState<Record<string, PanelState>>(() => {
     const basePanels = {
       blockPalette: {
@@ -197,8 +200,8 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({
   };
   
   const handleResetPosition = () => {
-    rules.forEach((rule) => {
-      rule.position = { x: 800, y: 300 }
+    rules.forEach((rule, index) => {
+      rule.position = { x: 800 + index * 340, y: 300 }
     });
     handleRecenter() // why would you look elsewhere if the windows are at the center
   };
@@ -1464,7 +1467,13 @@ const RuleBuilder: React.FC<RuleBuilderProps> = ({
               <WindowIcon className="h-4 w-4" />
             </button>
             <button
-              onClick={() => setGridSnapping((prev) => !prev)}
+              onClick={() => {
+                setUserConfig(prevConfig => ({
+                  ...prevConfig,
+                  defaultGridSnap: !gridSnapping
+                }))
+                setGridSnapping((prev) => !prev)
+              }}
               className={gridSnapping 
                 ? "p-1 text-mint-light hover:text-mint-lighter transition-colors cursor-pointer" 
                 : "p-1 text-white-darker hover:text-white transition-colors cursor-pointer"


### PR DESCRIPTION
saves to localstorage every selected filter and autoformat/grid snap
created a context to avoid propdrilling
we can use this in the future for any other site-related preferences (light theme, default item parameters idk)