### PR TITLE
Crash fix, allow debt fix, booster weight QoL temp change

### DIFF
--- a/src/components/codeGeneration/Jokers/effects/AllowDebtEffect.ts
+++ b/src/components/codeGeneration/Jokers/effects/AllowDebtEffect.ts
@@ -15,8 +15,8 @@ export const generatePassiveAllowDebt = (
     variableName
   )
 
-  const addToDeck = `G.GAME.bankrupt_at = G.GAME.bankrupt_at - (${valueCode})`;
-  const removeFromDeck = `G.GAME.bankrupt_at = G.GAME.bankrupt_at + (${valueCode})`;
+  const addToDeck = `G.GAME.bankrupt_at = G.GAME.bankrupt_at - ${valueCode}`;
+  const removeFromDeck = `G.GAME.bankrupt_at = G.GAME.bankrupt_at + ${valueCode}`;
 
   return {
     addToDeck,

--- a/src/components/data/Jokers/Effects.ts
+++ b/src/components/data/Jokers/Effects.ts
@@ -222,7 +222,7 @@ export const EFFECT_TYPES: EffectTypeDefinition[] = [
     applicableTriggers: ["passive"],
     params: [
       {
-        id: "debt_amount",
+        id: "value",
         type: "number",
         label: "Debt Amount",
         default: 20,

--- a/src/components/generic/ShowcaseModal.tsx
+++ b/src/components/generic/ShowcaseModal.tsx
@@ -40,7 +40,7 @@ const ShowcaseModal: React.FC<ShowcaseModalProps> = ({
     if (!showcaseRef.current) return;
 
     try {
-      const { toPng } = await import("html-to-image");
+      const { toPng } = await require("html-to-image");
 
       const dataUrl = await toPng(showcaseRef.current, {
         quality: 1,

--- a/src/components/pages/boosters/EditBoosterInfo.tsx
+++ b/src/components/pages/boosters/EditBoosterInfo.tsx
@@ -537,7 +537,7 @@ const EditBoosterInfo: React.FC<EditBoosterInfoProps> = ({
                                 type="range"
                                 min="0"
                                 max="10"
-                                step="0.1"
+                                step="0.05"
                                 value={formData.weight ?? 1}
                                 onChange={(e) =>
                                   onFormDataChange({
@@ -547,7 +547,7 @@ const EditBoosterInfo: React.FC<EditBoosterInfoProps> = ({
                                 className="flex-1 h-2 bg-black-lighter rounded appearance-none cursor-pointer"
                               />
                               <span className="text-mint font-mono w-16 text-sm">
-                                {(formData.weight ?? 1).toFixed(1)}
+                                {(formData.weight ?? 1).toFixed(2)}
                               </span>
                             </div>
                           </div>


### PR DESCRIPTION
- Fixed a crash that was found by a user, and was replicable on the newest version. Now no longer crashes by updating dynamic import --> require
- Fixed the 'allow debt' passive effect not working properly due to it exporting a nil value each time. (note, allow debt may be bugged in the sense that it may remain active if the joker is destroyed instead of sold, will need investigaition)
- Short term QoL change, booster pack weighting slider to allow for 2 decimals increased at .05 increments, doubling the current mobility, until a later change making the slider value directly inputable is made.