### PR TITLE
Vanilla reforged minor bug fixes and edits

### DIFF
--- a/public/vanillareforged.json
+++ b/public/vanillareforged.json
@@ -14354,10 +14354,16 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Tarot",
           "specific_type": "",
           "specific_key": "",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14385,10 +14391,16 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Tarot",
           "specific_type": "",
           "specific_key": "",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14416,10 +14428,16 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Tarot",
           "specific_type": "",
           "specific_key": "",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14447,10 +14465,16 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Tarot",
           "specific_type": "",
           "specific_key": "",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14478,10 +14502,16 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Tarot",
           "specific_type": "",
           "specific_key": "",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14509,10 +14539,16 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Tarot",
           "specific_type": "",
           "specific_key": "",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14540,10 +14576,16 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Tarot",
           "specific_type": "",
           "specific_key": "",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14571,10 +14613,16 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Tarot",
           "specific_type": "",
           "specific_key": "",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14834,8 +14882,14 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Spectral",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14863,8 +14917,14 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Spectral",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14892,8 +14952,14 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Spectral",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -14921,8 +14987,14 @@
       },
       "card_rules": [
         {
-          "weight": 1,
+          "weight": 2.99,
           "set": "Spectral",
+          "edition": "none"
+        },{
+          "weight": 0.01,
+          "set": "Spectral",
+          "specific_type": "consumable",
+          "specific_key": "c_soul",
           "edition": "none"
         }
       ],
@@ -15271,7 +15343,7 @@
                   "id": "ff9f5c6a-b0b6-4319-ac81-8e1828857e0a",
                   "type": "destroy_card",
                   "params": {
-                    "setGlassTrigger": "false"
+                    "setGlassTrigger": "true"
                   }
                 }
               ]

--- a/src/components/pages/BoostersPage.tsx
+++ b/src/components/pages/BoostersPage.tsx
@@ -326,8 +326,8 @@ export const CardRuleEditor: React.FC<CardRuleEditorProps> = ({
                     <input
                       type="range"
                       min="0"
-                      max="2"
-                      step="0.1"
+                      max="5"
+                      step="0.05"
                       value={rule.weight ?? 1}
                       onChange={(e) =>
                         handleUpdateRule(index, {
@@ -337,7 +337,7 @@ export const CardRuleEditor: React.FC<CardRuleEditorProps> = ({
                       className="flex-1 h-2 bg-black-lighter rounded appearance-none cursor-pointer"
                     />
                     <span className="text-mint font-mono w-12 text-sm">
-                      {(rule.weight ?? 1).toFixed(1)}
+                      {(rule.weight ?? 1).toFixed(2)}
                     </span>
                   </div>
                 </div>
@@ -359,8 +359,8 @@ export const CardRuleEditor: React.FC<CardRuleEditorProps> = ({
                     <input
                       type="range"
                       min="0"
-                      max="2"
-                      step="0.1"
+                      max="5"
+                      step="0.05"
                       value={rule.weight ?? 1}
                       onChange={(e) =>
                         handleUpdateRule(index, {
@@ -370,7 +370,7 @@ export const CardRuleEditor: React.FC<CardRuleEditorProps> = ({
                       className="flex-1 h-2 bg-black-lighter rounded appearance-none cursor-pointer"
                     />
                     <span className="text-mint font-mono w-12 text-sm">
-                      {(rule.weight ?? 1).toFixed(1)}
+                      {(rule.weight ?? 1).toFixed(2)}
                     </span>
                   </div>
                 </div>

--- a/src/components/pages/vanillareforged/BoostersVanillaReforgedPage.tsx
+++ b/src/components/pages/vanillareforged/BoostersVanillaReforgedPage.tsx
@@ -524,7 +524,7 @@ const BoostersVanillaReforgedPage: React.FC<
           <EditBoosterRulesModal
             isOpen={showBoosterRulesModal}
             onClose={handleCloseBoosterRulesModal}
-            onSave={() => {}}
+            onSave={handleCloseBoosterRulesModal}
             cardRules={currentItemForRules.card_rules || []}
             boosterType={currentItemForRules.booster_type}
             consumableSets={[] as ConsumableSetData[]}


### PR DESCRIPTION
- Changed blueprint compatability visual and internal parameters for some jokers and rules in vanilla reforged to match the rules of the base game
- Filled out some blank parameters for consumables that create Jokers
- Added 'The Soul' to Arcana and Spectral pack ruleset.
- Adjusted booster pack rule weighting slider to accomodate the former change
- Fixed 'save' not closing the edit rules menu for vanilla reforged (though bc its vanilla reforged it doesn't actually save, just closes)
- Fixed glass card not set to trigger glass joker