### PR TITLE
Feat: Added Id's to Jokers + More QoL changes

### DIFF
--- a/src/components/JSONImportExport.ts
+++ b/src/components/JSONImportExport.ts
@@ -47,7 +47,6 @@ export const normalizeImportedModData = (data: ImportableModData) => {
   if (!data.jokers || !Array.isArray(data.jokers)) {
     throw new Error("Invalid mod data - missing or invalid jokers data");
   }
-
   const normalizedJokers = data.jokers.map(normalizeJokerData);
   const normalizedSounds = (data.sounds || []).map(normalizeSoundData);
   const normalizedConsumables = (data.consumables || []).map(
@@ -130,6 +129,7 @@ const normalizeJokerData = (joker: Partial<JokerData>): JokerData => {
     scale_h: joker.scale_h || 100,
     scale_w: joker.scale_w || 100,
     pools: joker.pools || [],
+    orderValue: joker.orderValue || 0,
   };
 };
 

--- a/src/components/data/BalatroUtils.ts
+++ b/src/components/data/BalatroUtils.ts
@@ -93,6 +93,7 @@ export interface JokerData {
   imagePreview: string;
   overlayImagePreview?: string;
   rarity: number | string;
+  orderValue: number;
   cost?: number;
   blueprint_compat?: boolean;
   eternal_compat?: boolean;

--- a/src/components/generic/ShowcaseModal.tsx
+++ b/src/components/generic/ShowcaseModal.tsx
@@ -14,7 +14,7 @@ import {
   UserVariable,
 } from "../data/BalatroUtils";
 import { getAllVariables } from "../codeGeneration/Jokers/variableUtils";
-import { toPng } from "html-to-image";
+// import { toPng } from "html-to-image";
 
 interface ShowcaseModalProps {
   isOpen: boolean;
@@ -86,7 +86,7 @@ const ShowcaseModal: React.FC<ShowcaseModalProps> = ({
   const handleDownload = async () => {
     if (!showcaseRef.current) return;
 
-    try {
+    /*try {
       const dataUrl = await toPng(showcaseRef.current, {
         quality: 1,
         pixelRatio: 2,
@@ -103,7 +103,7 @@ const ShowcaseModal: React.FC<ShowcaseModalProps> = ({
       alert(
         "Screenshot failed. Please use your browser's screenshot feature instead."
       );
-    }
+    }*/
   };
 
   const allVariables = getAllVariables(joker);

--- a/src/components/pages/JokersPage.tsx
+++ b/src/components/pages/JokersPage.tsx
@@ -17,7 +17,6 @@ import type { Rule } from "../ruleBuilder/types";
 import { RarityData, JokerData } from "../data/BalatroUtils";
 import { UserConfigContext } from "../Contexts";
 import ShowcaseModal from "../generic/ShowcaseModal";
-import { number } from "framer-motion";
 
 interface JokersPageProps {
   modName: string;
@@ -74,6 +73,35 @@ const upscaleImage = (imageSrc: string): Promise<string> => {
     img.src = imageSrc;
   });
 };
+
+export const getJokerName = function(joker:JokerData,jokers:JokerData[],value?:string){
+  let newNumber:number|boolean|string
+  let tempName:string = ''
+  let currentName 
+  let dupeName:string|null = value||null
+  if (dupeName && !jokers.some(listJoker => listJoker.name == dupeName && joker.id !== listJoker.id)){
+    return dupeName}
+  while (true){
+    let count:number = 0
+    let looping = true
+    let match     
+    currentName = dupeName || joker.name
+    tempName = currentName
+    while (looping == true){
+      match = tempName.match(/\d+$/) 
+      if (match){
+        tempName=tempName.slice(0,-1)
+        count +=1}
+      else{looping=false}}
+    if (count>0)
+      {newNumber = Number(currentName.substring(currentName.length-Number(count),currentName.length))+1}
+    else {newNumber = false} 
+    if (newNumber !== false){
+      dupeName = currentName.slice(0,-count)+String(newNumber)}
+    else {dupeName = currentName+'2'}
+    if (dupeName && !jokers.some(listJoker => listJoker.name == dupeName && joker.id !== listJoker.id)){
+      return dupeName
+}}}
 
 const getRandomPlaceholderJoker = async (): Promise<{
   imageData: string;
@@ -388,25 +416,7 @@ const JokersPage: React.FC<JokersPageProps> = ({
   const handleDuplicateJoker = async (joker: JokerData) => {
     if (isPlaceholderJoker(joker.imagePreview)) {
       const placeholderResult = await getRandomPlaceholderJoker();
-      let newNumber:number|boolean|string
-      let dupeName:string
-      let tempName=joker.name
-      let count:number = 0
-      let looping = true
-      let match
-      while (looping == true){
-        match = tempName.match(/\d+$/) 
-        if (match){
-          tempName=tempName.slice(0,-1)
-          count +=1}
-        else{looping=false
-           break}}
-      if (count>0)
-        {newNumber = Number(joker.name.substring(joker.name.length-Number(count),joker.name.length))+1
-      } else {newNumber = false} 
-      if (newNumber !== false){
-        dupeName = joker.name.slice(0,-count)+String(newNumber)}
-      else {dupeName= joker.name+'2'}
+      const dupeName = getJokerName(joker,jokers)
       const duplicatedJoker: JokerData = {
         ...joker,
         id: crypto.randomUUID(),
@@ -422,10 +432,11 @@ const JokersPage: React.FC<JokersPageProps> = ({
         currentJoker.orderValue +=1
       }}
     } else {
+      const dupeName = getJokerName(joker,jokers)
       const duplicatedJoker: JokerData = {
         ...joker,
         id: crypto.randomUUID(),
-        name: `${joker.name} Copy`,
+        name: `${dupeName}`,
         orderValue: joker.orderValue+1,
       };
       setJokers([...jokers, duplicatedJoker]);
@@ -681,6 +692,7 @@ const JokersPage: React.FC<JokersPageProps> = ({
           <EditJokerInfo
             isOpen={!!editingJoker}
             joker={editingJoker}
+            jokers={jokers}
             onClose={() => setEditingJoker(null)}
             onSave={handleSaveJoker}
             onDelete={handleDeleteJoker}

--- a/src/components/pages/jokers/EditJokerInfo.tsx
+++ b/src/components/pages/jokers/EditJokerInfo.tsx
@@ -47,10 +47,12 @@ import {
   unlockTriggerOptions,
 } from "../../codeGeneration/Jokers/unlockUtils";
 import { UserConfigContext } from "../../Contexts";
+import { getJokerName } from "../JokersPage";
 
 interface EditJokerInfoProps {
   isOpen: boolean;
   joker: JokerData;
+  jokers: JokerData[];
   onClose: () => void;
   onSave: (joker: JokerData) => void;
   onDelete: (jokerId: string) => void;
@@ -77,6 +79,7 @@ type UnlockTrigger = keyof typeof unlockOptions;
 const EditJokerInfo: React.FC<EditJokerInfoProps> = ({
   isOpen,
   joker,
+  jokers,
   onClose,
   onSave,
   onDelete,
@@ -393,6 +396,7 @@ const EditJokerInfo: React.FC<EditJokerInfoProps> = ({
         [field]: finalValue,
       });
     } else if (field === "name") {
+      value = getJokerName(joker, jokers, value)
       setFormData({
         ...formData,
         [field]: value,

--- a/src/components/pages/jokers/EditJokerInfo.tsx
+++ b/src/components/pages/jokers/EditJokerInfo.tsx
@@ -47,7 +47,7 @@ import {
   unlockTriggerOptions,
 } from "../../codeGeneration/Jokers/unlockUtils";
 import { UserConfigContext } from "../../Contexts";
-import { getJokerName } from "../JokersPage";
+import { updateJokerIds, getJokerName } from "../JokersPage";
 
 interface EditJokerInfoProps {
   isOpen: boolean;
@@ -652,6 +652,7 @@ const EditJokerInfo: React.FC<EditJokerInfoProps> = ({
       onConfirm: () => {
         onDelete(joker.id);
         onClose();
+        jokers = updateJokerIds(joker, jokers, 'remove', joker.orderValue) 
       },
     });
   };

--- a/src/components/pages/jokers/JokerCard.tsx
+++ b/src/components/pages/jokers/JokerCard.tsx
@@ -33,7 +33,7 @@ import {
   slugify,
 } from "../../data/BalatroUtils";
 import { getJokerName } from "../JokersPage";
-
+import { updateJokerIds } from "../JokersPage";
 
 interface JokerCardProps {
   joker: JokerData;
@@ -171,16 +171,10 @@ const JokerCard: React.FC<JokerCardProps> = ({
   const handleIdSave = () => {
     const priorValue = joker.orderValue
     const newValue = tempId
-    onQuickUpdate({ orderValue: Math.max(1,Math.min(tempId,jokers.length+1)) });
+    onQuickUpdate({ orderValue: Math.max(1,Math.min(tempId,jokers.length)) });
     setEditingId(false);
-    for (let i=0; i<jokers.length;i++){
-      const currentJoker = jokers[i]
-      if (currentJoker.orderValue >= newValue && currentJoker.orderValue < priorValue && currentJoker.id !== joker.id){
-        currentJoker.orderValue +=1
-      }else if (currentJoker.orderValue <= newValue && currentJoker.orderValue > priorValue && currentJoker.id !== joker.id){
-        currentJoker.orderValue -=1
-      }
-    }
+    const direction = (priorValue>newValue)?'decrease':'increase'
+    jokers = updateJokerIds(joker, jokers, 'change', newValue, direction, priorValue)
   };
 
   const handleDescriptionSave = () => {
@@ -511,7 +505,9 @@ const JokerCard: React.FC<JokerCardProps> = ({
                   confirmText: "Delete Forever",
                   cancelText: "Keep It",
                   confirmVariant: "danger",
-                  onConfirm: () => onDelete(),
+                  onConfirm: () => {onDelete()
+                  jokers = updateJokerIds(joker, jokers, 'remove', joker.orderValue)}
+                  ,
                 });
               }}
               className="w-full h-full flex items-center cursor-pointer justify-center"

--- a/src/components/pages/jokers/JokerCard.tsx
+++ b/src/components/pages/jokers/JokerCard.tsx
@@ -32,6 +32,8 @@ import {
   type JokerData,
   slugify,
 } from "../../data/BalatroUtils";
+import { getJokerName } from "../JokersPage";
+
 
 interface JokerCardProps {
   joker: JokerData;
@@ -154,7 +156,9 @@ const JokerCard: React.FC<JokerCardProps> = ({
       return;
     }
 
-    onQuickUpdate({ name: tempName, jokerKey: slugify(tempName) });
+    const finalName = getJokerName(joker,jokers, tempName)
+
+    onQuickUpdate({ name: finalName, jokerKey: slugify(finalName) });
     setEditingName(false);
     setNameValidationError("");
   };

--- a/src/components/pages/jokers/JokerCard.tsx
+++ b/src/components/pages/jokers/JokerCard.tsx
@@ -32,9 +32,11 @@ import {
   type JokerData,
   slugify,
 } from "../../data/BalatroUtils";
+import { kMaxLength } from "buffer";
 
 interface JokerCardProps {
   joker: JokerData;
+  jokers: JokerData[];
   onEditInfo: () => void;
   onEditRules: () => void;
   onDelete: () => void;
@@ -100,6 +102,7 @@ const PropertyIcon: React.FC<{
 
 const JokerCard: React.FC<JokerCardProps> = ({
   joker,
+  jokers,
   onEditInfo,
   onEditRules,
   onDelete,
@@ -114,11 +117,14 @@ const JokerCard: React.FC<JokerCardProps> = ({
   const [editingName, setEditingName] = useState(false);
   const [editingCost, setEditingCost] = useState(false);
   const [editingDescription, setEditingDescription] = useState(false);
+  const [editingId, setEditingId] = useState(false);
   const [tempName, setTempName] = useState(joker.name);
   const [tempCost, setTempCost] = useState(joker.cost || 4);
+  const [tempId, setTempId] = useState(joker.orderValue);
   const [tempDescription, setTempDescription] = useState(joker.description);
   const [hoveredButton, setHoveredButton] = useState<string | null>(null);
   const [hoveredTrash, setHoveredTrash] = useState(false);
+  const [hoveredId, setHoveredId] = useState(false);
   const [tooltipDelayTimeout, setTooltipDelayTimeout] =
     useState<NodeJS.Timeout | null>(null);
 
@@ -155,8 +161,23 @@ const JokerCard: React.FC<JokerCardProps> = ({
   };
 
   const handleCostSave = () => {
-    onQuickUpdate({ cost: tempCost });
+    onQuickUpdate({ cost: Math.min(tempCost,999)});
     setEditingCost(false);
+  };
+
+  const handleIdSave = () => {
+    const priorValue = joker.orderValue
+    const newValue = tempId
+    onQuickUpdate({ orderValue: Math.max(1,Math.min(tempId,jokers.length)) });
+    setEditingId(false);
+    for (let i=0; i<jokers.length;i++){
+      const currentJoker = jokers[i]
+      if (currentJoker.orderValue >= newValue && currentJoker.orderValue < priorValue && currentJoker.id !== joker.id){
+        currentJoker.orderValue +=1
+      }else if (currentJoker.orderValue <= newValue && currentJoker.orderValue > priorValue && currentJoker.id !== joker.id){
+        currentJoker.orderValue -=1
+      }
+    }
   };
 
   const handleDescriptionSave = () => {
@@ -212,6 +233,24 @@ const JokerCard: React.FC<JokerCardProps> = ({
       setTooltipDelayTimeout(null);
     }
     setHoveredTrash(false);
+  };
+
+  const handleIdHover = () => {
+    if (tooltipDelayTimeout) {
+      clearTimeout(tooltipDelayTimeout);
+    }
+    const timeout = setTimeout(() => {
+      setHoveredId(true);
+    }, 500);
+    setTooltipDelayTimeout(timeout);
+  };
+
+  const handleIdLeave = () => {
+    if (tooltipDelayTimeout) {
+      clearTimeout(tooltipDelayTimeout);
+      setTooltipDelayTimeout(null);
+    }
+    setHoveredId(false);
   };
 
   const blueprintCompat = joker.blueprint_compat !== false;
@@ -421,9 +460,41 @@ const JokerCard: React.FC<JokerCardProps> = ({
       </div>
 
       <div className="my-auto border-l-2 pl-4 border-black-light relative flex-1 min-h-fit">
+        <Tooltip content = "Edit Joker Id"show={hoveredId}>
+          <div 
+            className="absolute min-w-13 -top-3 right-7 h-8 bg-black-dark border-2 border-balatro-orange rounded-lg p-1 cursor-pointer transition-colors flex items-center justify-center z-10"
+            onMouseEnter={handleIdHover}
+            onMouseLeave={handleIdLeave}>
+            {editingId ? (
+            <input 
+              type="number"
+              value={tempId}
+              onChange={(e) => setTempId(parseInt(e.target.value))}
+              onBlur={handleIdSave}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleIdSave();
+                if (e.key === "Escape") {
+                  setTempId(joker.orderValue);
+                  setEditingId(false);
+                }
+              }}
+              className="bg-black-dark text-center text-balatro-orange outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              autoFocus
+              />):(
+            <span
+              className="text-center text-balatro-orange outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              onClick={() => {
+                setTempId(joker.orderValue);
+                setEditingId(true);
+              }}
+            >
+              Id:{joker.orderValue}
+            </span>)}
+            </div>
+        </Tooltip>
         <Tooltip content="Delete Joker" show={hoveredTrash}>
           <div
-            className="absolute -top-3 -right-3 bg-black-dark border-2 border-balatro-red rounded-lg p-1 hover:bg-balatro-redshadow cursor-pointer transition-colors flex items-center justify-center z-10"
+            className="absolute -top-3 -right-3 h-8 bg-black-dark border-2 border-balatro-red rounded-lg p-1 hover:bg-balatro-redshadow cursor-pointer transition-colors flex items-center justify-center z-10"
             onMouseEnter={handleTrashHover}
             onMouseLeave={handleTrashLeave}
           >

--- a/src/components/pages/jokers/JokerCard.tsx
+++ b/src/components/pages/jokers/JokerCard.tsx
@@ -32,7 +32,6 @@ import {
   type JokerData,
   slugify,
 } from "../../data/BalatroUtils";
-import { kMaxLength } from "buffer";
 
 interface JokerCardProps {
   joker: JokerData;

--- a/src/components/pages/jokers/JokerCard.tsx
+++ b/src/components/pages/jokers/JokerCard.tsx
@@ -171,7 +171,7 @@ const JokerCard: React.FC<JokerCardProps> = ({
   const handleIdSave = () => {
     const priorValue = joker.orderValue
     const newValue = tempId
-    onQuickUpdate({ orderValue: Math.max(1,Math.min(tempId,jokers.length)) });
+    onQuickUpdate({ orderValue: Math.max(1,Math.min(tempId,jokers.length+1)) });
     setEditingId(false);
     for (let i=0; i<jokers.length;i++){
       const currentJoker = jokers[i]


### PR DESCRIPTION
Joker Id's allow for customising the user experience with their own order or jokers in both joker forge, and in the balatro collection. Each Joker has it's own unique Id that will adapt based on changes to other Jokers Id's so that no two are alike (hopefully if it isn't bugged somehow)

Other features:
- Changed duplicating joker code to add a number instead of the word 'copy', and the number will count up if a duplicate of a duplicate is created
- Changed export order to be by Id instead of alphabetical
- Added 'sort by Id' on the Joker page
- Joker names will now be unique for every single joker, to make the download process for a mod neater and work in all cases with the new Id system