### PR TITLE
Fixed bugs in CopyJokerEffect and EditCardEffect

### DIFF
--- a/src/components/codeGeneration/Effects/CopyJokerEffect.ts
+++ b/src/components/codeGeneration/Effects/CopyJokerEffect.ts
@@ -31,7 +31,7 @@ const generateJokerCode = (
   const jokerKey = (effect.params?.joker_key?.value as string) || "";
   const position = (effect.params?.position?.value as string) || "first";
   const specificIndex = (effect.params?.specific_index?.value as number) || 1;
-  const edition = (effect.params?.edition?.value as string) || "none";
+  const edition = effect.params?.edition?.value ? `e_${effect.params.edition.value}` : "none";
   const customMessage = effect.customMessage;
   const ignoreSlots = (effect.params?.ignore_slots?.value as string) === "ignore";
   const sticker = (effect.params?.sticker?.value as string) || "none"
@@ -195,7 +195,7 @@ const generateConsumableCode = (
 ): EffectReturn => {
   const selection_method = effect.params?.selection_method?.value as string || "random";
   const amount = effect.params?.amount?.value as string || '1';
-  const edition = effect.params?.edition?.value as string || "none";
+  const edition = effect.params?.edition?.value ? `e_${effect.params.edition.value}` : "none";
   const customMessage = effect.customMessage;
 
   let copyJokerCode = `
@@ -312,7 +312,7 @@ const generateCardCode = (
     (effect.params?.selection_method?.value as string) || "random";
   const jokerKey = (effect.params?.joker_key?.value as string) || "";
   const position = (effect.params?.position?.value as string) || "first";
-  const edition = (effect.params?.edition?.value as string) || "none";
+  const edition = effect.params?.edition?.value ? `e_${effect.params.edition.value}` : "none";
   const customMessage = effect.customMessage;
 
   const normalizedJokerKey = jokerKey.startsWith("j_") 

--- a/src/components/codeGeneration/Effects/CopyJokerEffect.ts
+++ b/src/components/codeGeneration/Effects/CopyJokerEffect.ts
@@ -31,7 +31,11 @@ const generateJokerCode = (
   const jokerKey = (effect.params?.joker_key?.value as string) || "";
   const position = (effect.params?.position?.value as string) || "first";
   const specificIndex = (effect.params?.specific_index?.value as number) || 1;
-  const edition = effect.params?.edition?.value ? `e_${effect.params.edition.value}` : "none";
+  const edition = (effect.params?.edition?.value as string) || "none";
+  const normalizedEdition = //Added by Errynei to fix the prefix "e_" not being added to editions
+      edition === "none" || edition.startsWith("e_")
+          ? edition
+          : `e_${edition}`;
   const customMessage = effect.customMessage;
   const ignoreSlots = (effect.params?.ignore_slots?.value as string) === "ignore";
   const sticker = (effect.params?.sticker?.value as string) || "none"
@@ -39,7 +43,7 @@ const generateJokerCode = (
   const scoringTriggers = ["hand_played", "card_scored"];
   const isScoring = scoringTriggers.includes(triggerType);
 
-  const isNegative = edition === "e_negative";
+  const isNegative = normalizedEdition === "e_negative";
   const hasEdition = edition !== "none";
   const hasSticker = sticker !== "none";
 
@@ -141,7 +145,7 @@ const generateJokerCode = (
   // Generate copy logic
   const editionCode = hasEdition
     ? `
-                        copied_joker:set_edition("${edition}", true)`
+                        copied_joker:set_edition("${normalizedEdition}", true)`
     : "";
   const stickerCode = hasSticker
     ? `copied_joker:add_sticker('${sticker}', true)`
@@ -195,7 +199,11 @@ const generateConsumableCode = (
 ): EffectReturn => {
   const selection_method = effect.params?.selection_method?.value as string || "random";
   const amount = effect.params?.amount?.value as string || '1';
-  const edition = effect.params?.edition?.value ? `e_${effect.params.edition.value}` : "none";
+  const edition = (effect.params?.edition?.value as string) || "none";
+  const normalizedEdition = //Added by Errynei to fix the prefix "e_" not being added to editions
+      edition === "none" || edition.startsWith("e_")
+          ? edition
+          : `e_${edition}`;
   const customMessage = effect.customMessage;
 
   let copyJokerCode = `
@@ -269,7 +277,7 @@ __PRE_RETURN_CODE__
               copied_joker:set_edition(edition, true)`;
   } else if (edition !== "none") {
         copyJokerCode += `
-              copied_joker:set_edition('${edition}', true)`;
+              copied_joker:set_edition('${normalizedEdition}', true)`;
   }
 
 if (selection_method === "selected") {
@@ -312,14 +320,18 @@ const generateCardCode = (
     (effect.params?.selection_method?.value as string) || "random";
   const jokerKey = (effect.params?.joker_key?.value as string) || "";
   const position = (effect.params?.position?.value as string) || "first";
-  const edition = effect.params?.edition?.value ? `e_${effect.params.edition.value}` : "none";
+  const edition = (effect.params?.edition?.value as string) || "none";
+  const normalizedEdition = //Added by Errynei to fix the prefix "e_" not being added to editions
+      edition === "none" || edition.startsWith("e_")
+          ? edition
+          : `e_${edition}`;
   const customMessage = effect.customMessage;
 
   const normalizedJokerKey = jokerKey.startsWith("j_") 
   ? jokerKey 
   : `j_${jokerKey}`
 
-  const isNegative = edition === "e_negative";
+    const isNegative = normalizedEdition === "e_negative";
   const hasEdition = edition !== "none";
 
   let jokerSelectionCode = "";
@@ -359,7 +371,7 @@ const generateCardCode = (
 
   const editionCode = hasEdition
     ? `
-                        copied_joker:set_edition("${edition}", true)`
+                        copied_joker:set_edition("${normalizedEdition}", true)`
     : "";
 
   const bufferCode = isNegative

--- a/src/components/codeGeneration/Effects/EditCardEffect.ts
+++ b/src/components/codeGeneration/Effects/EditCardEffect.ts
@@ -1,6 +1,6 @@
 import type { Effect } from "../../ruleBuilder/types";
 import type { EffectReturn } from "../lib/effectUtils";
-import { EDITIONS, getRankId } from "../../data/BalatroUtils";
+import { EDITIONS, getRankId, getRankLabelById } from "../../data/BalatroUtils";
 
 export const generateEditCardEffectCode = (
   effect: Effect,
@@ -60,7 +60,7 @@ const generateJokerCode = (
     } else if (newRank.value === "random") {
       rankParam = "pseudorandom_element(SMODS.Ranks, 'edit_card_rank').key";
     } else if (newRank.value !== "none") {
-      rankParam = `"${getRankId(newRank.value as string)}"`;
+        rankParam = `"${getRankLabelById(getRankId(newRank.value as string))}"`;
     }
 
     modificationCode += `
@@ -179,7 +179,7 @@ const generateCardCode = (
     if (newRank === "random") {
       rankParam = "pseudorandom_element(SMODS.Ranks, 'edit_card_rank').key";
     } else if (newRank !== "none") {
-      rankParam = `"${getRankId(newRank)}"`;
+        rankParam = `"${getRankLabelById(getRankId(newRank))}"`;
     }
 
     modificationCode += `

--- a/src/components/data/BalatroUtils.ts
+++ b/src/components/data/BalatroUtils.ts
@@ -1968,6 +1968,12 @@ export const getRankById = (id: number) => {
   return RANKS.find((rank) => rank.id === id);
 };
 
+// Get rank label by ID 
+// (Added by Errynei for bug fix that expected the label, not the rank value, in EditCardEffect.ts)
+export const getRankLabelById = (id: number) => {
+    return RANKS.find((rank) => rank.id === id)?.label;
+};
+
 // Get suit data by value
 export const getSuitByValue = (value: string) => {
   return SUITS.find((suit) => suit.value === value);


### PR DESCRIPTION
- CopyJokerEffect was not including the "e_" prefix for assigning the edition, I created a normalized version of the "edition" variable and passed that into the codeGen instead
- EditCardEffect was using "11" "12" "13" and "14" passed into a method that expected "Jack" "Queen" "King" or "Ace", I added a method to BalatroUtils.ts for retrieving the "label" associated with the rank, and imported it in EditCardEffect and wrapped each "getRankId" method with my "getRankLabelById" instead